### PR TITLE
fix read_table, make it return the table name as well

### DIFF
--- a/src/utils.py
+++ b/src/utils.py
@@ -24,6 +24,14 @@ def read_table(table_name, conn, after_time):
 
 
 def convert_data(data):
+    """
+    converts the data passed in into json format
+
+    takes the argument for:
+    the data, in string form, ready to convert to json
+
+    returns a json object, ready to upload into the bucket as a json file
+    """
     try:
         return json.dumps(data)
     except (ValueError, TypeError) as error:

--- a/src/utils.py
+++ b/src/utils.py
@@ -10,21 +10,17 @@ def read_table(table_name, conn, after_time):
     the connection to the database,
     the time which to select records updated after (ie the last time the function was run)
 
-    returns a string to be converted into json
+    returns a dict in the format {table_name: <string to be converted into json>}
     """
-    # try:
     result = conn.run(
         f"""
-        SELECT * FROM :table_name
+        SELECT * FROM {table_name}
         WHERE last_updated > :after_time
         """,
-        table_name=table_name,
         after_time=after_time,
     )
 
-    return result
-    # except Exception:
-    #     raise ValueError
+    return {table_name: result}
 
 
 def convert_data(data):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -19,13 +19,14 @@ class TestReadTable:
         # assert
         test_conn.run.assert_called_once_with(
             f"""
-        SELECT * FROM :table_name
+        SELECT * FROM {test_table_name}
         WHERE last_updated > :after_time
         """,
-            table_name=test_table_name,
             after_time=test_time,
         )
-        assert result == "{result: {id: 2, last_updated: '2010-01-01', value: 'row 2'}}"
+        assert result == {
+            "test_table": "{result: {id: 2, last_updated: '2010-01-01', value: 'row 2'}}"
+        }
 
     # def test_raises_value_error(self):
     #     test_conn = Mock()


### PR DESCRIPTION
The query should now take in the table name properly, and the return is now a dictionary, attaching the table name as a key to the old return value.